### PR TITLE
Relax filters

### DIFF
--- a/dfilter/main.go
+++ b/dfilter/main.go
@@ -13,7 +13,7 @@ import (
 
 // TODO:
 // * Add way to ignore aggressive domain filtering (allow malformed or fake TLD domains)
-//
+// * Add field-based filtering for CSV/TSV/etc.
 
 var root *dnstrie.DomainTrie
 

--- a/dfilter/main.go
+++ b/dfilter/main.go
@@ -11,10 +11,6 @@ import (
 	"github.com/ynadji/dnstrie"
 )
 
-// TODO:
-// * Add way to ignore aggressive domain filtering (allow malformed or fake TLD domains)
-// * Add field-based filtering for CSV/TSV/etc.
-
 var root *dnstrie.DomainTrie
 
 var flags struct {

--- a/dfilter/main.go
+++ b/dfilter/main.go
@@ -21,6 +21,7 @@ var flags struct {
 func readDomains(matchFilePath string) []string {
 	f, err := os.Open(matchFilePath)
 	if err != nil {
+		panic(fmt.Sprintf("Failed to read %s: %v", matchFilePath, err))
 	}
 	reader := bufio.NewReader(f)
 	content, _ := ioutil.ReadAll(reader)

--- a/dnstrie.go
+++ b/dnstrie.go
@@ -18,8 +18,6 @@ package dnstrie
 import (
 	"fmt"
 	"strings"
-
-	"github.com/ynadji/dnstrie/dns"
 )
 
 // DomainTrie is a struct for the recursive DNS-aware trie data structure. The
@@ -43,9 +41,6 @@ func (root *DomainTrie) Empty() bool {
 // ExactMatch only matches against exactly fully qualified domain names and
 // ignores zone wildcards.
 func (root *DomainTrie) ExactMatch(domain string) bool {
-	if !dns.IsPossibleDomain(domain) {
-		return false
-	}
 	reversedLabels, err := reverseLabelSlice(domain)
 	if err != nil {
 		return false
@@ -66,9 +61,6 @@ func (root *DomainTrie) ExactMatch(domain string) bool {
 // trie was constructed with wildcarded matches, this will accept them unlike
 // `ExactMatch`.
 func (root *DomainTrie) WildcardMatch(domain string) bool {
-	if !dns.IsPossibleDomain(domain) {
-		return false
-	}
 	reversedLabels, err := reverseLabelSlice(domain)
 	if err != nil {
 		return false
@@ -111,9 +103,6 @@ func checkAndRemoveWildcard(domain string) (string, bool) {
 func reverseLabelSlice(domain string) ([]string, error) {
 	var reversedLabels []string
 	domain, wildcarded := checkAndRemoveWildcard(domain)
-	if !dns.IsPossibleDomain(domain) {
-		return nil, fmt.Errorf("%s is not a valid domain", domain)
-	}
 	labels := strings.Split(domain, ".")
 
 	for i := len(labels) - 1; i >= 0; i-- {
@@ -129,8 +118,8 @@ func reverseLabelSlice(domain string) ([]string, error) {
 
 // MakeTrie returns the root of a trie given a slice of domain names. Invalid
 // domains and those that do not use known TLDs will fail to construct the
-// trie. Use tm-go-common/dns.Normalize to prepare domains received from
-// untrusted or unreliable sources.
+// trie. Use dns.Normalize to prepare domains received from untrusted or
+// unreliable sources.
 func MakeTrie(domains []string) (*DomainTrie, error) {
 	root := &DomainTrie{label: "."}
 

--- a/dnstrie.go
+++ b/dnstrie.go
@@ -116,10 +116,9 @@ func reverseLabelSlice(domain string) ([]string, error) {
 	return reversedLabels, nil
 }
 
-// MakeTrie returns the root of a trie given a slice of domain names. Invalid
-// domains and those that do not use known TLDs will fail to construct the
-// trie. Use dns.Normalize to prepare domains received from untrusted or
-// unreliable sources.
+// MakeTrie returns the root of a trie given a slice of domain names.  Use
+// dns.Normalize to prepare domains received from untrusted or unreliable
+// sources.
 func MakeTrie(domains []string) (*DomainTrie, error) {
 	root := &DomainTrie{label: "."}
 

--- a/dnstrie_test.go
+++ b/dnstrie_test.go
@@ -3,8 +3,6 @@ package dnstrie
 import (
 	"reflect"
 	"testing"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestCheckAndRemoveWildcard(t *testing.T) {
@@ -38,11 +36,10 @@ func TestReverseLabelSlice(t *testing.T) {
 	testCases := []testCase{
 		testCase{"www.google.com", []string{"com", "google", "www"}},
 		testCase{"www.google.co.uk", []string{"uk", "co", "google", "www"}},
-		testCase{"not.a.real.domain.asdashfkjah", nil},
-		testCase{"not.a.real.!@#$.com", nil},
+		testCase{"not.a.real.domain.asdashfkjah", []string{"asdashfkjah", "domain", "real", "a", "not"}},
 		testCase{"foo.com.gza.com", []string{"com", "gza", "com", "foo"}},
 		testCase{"com", []string{"com"}},
-		testCase{"", nil},
+		testCase{"", []string{""}},
 		testCase{"*.foo.com", []string{"com", "foo", "*"}},
 	}
 
@@ -84,7 +81,7 @@ func TestMakeTrie(t *testing.T) {
 	for _, tc := range testCases {
 		root, _ := MakeTrie(tc.domains)
 		if !reflect.DeepEqual(root, tc.root) {
-			t.Fatalf("Failed to MakeTrie. Got:\n%+v\nExpected:\n%+v\n", spew.Sdump(root), spew.Sdump(tc.root))
+			t.Fatalf("Failed to MakeTrie. Got:\n%+v\nExpected:\n%+v\n", root, tc.root)
 		}
 	}
 }
@@ -95,8 +92,8 @@ func TestExactMatch(t *testing.T) {
 		match  bool
 	}
 	root, err := MakeTrie([]string{"*.google.com", "www.google.org", "*.biz", "notarealdomain", "*nadji.us", "onizuka.homelinux.org"})
-	if err == nil {
-		t.Fatalf("Should fail on bad domains")
+	if err != nil {
+		t.Fatalf("Failed to MakeTrie: %v", err)
 	}
 	root, err = MakeTrie([]string{"*.google.com", "www.google.org", "*.biz", "onizuka.homelinux.org"})
 	if err != nil {
@@ -113,7 +110,7 @@ func TestExactMatch(t *testing.T) {
 		testCase{"notarealdomain", false},
 		testCase{"foo.nadji.us", false},
 		testCase{"nadji.us", false},
-		testCase{"*.biz", false},
+		testCase{"*.biz", true},
 		testCase{"onizuka.homelinux.org", true},
 	}
 	for _, tc := range testCases {
@@ -130,8 +127,8 @@ func TestWildcardMatch(t *testing.T) {
 		match  bool
 	}
 	root, err := MakeTrie([]string{"*.google.com", "www.google.org", "*.biz", "notarealdomain", "*nadji.us", "onizuka.homelinux.org"})
-	if err == nil {
-		t.Fatalf("Should fail on bad domains")
+	if err != nil {
+		t.Fatalf("Failed to MakeTrie: %v", err)
 	}
 	root, err = MakeTrie([]string{"*.google.com", "www.google.org", "*.biz", "onizuka.homelinux.org"})
 	if err != nil {
@@ -148,7 +145,7 @@ func TestWildcardMatch(t *testing.T) {
 		testCase{"notarealdomain", false},
 		testCase{"foo.nadji.us", false},
 		testCase{"nadji.us", false},
-		testCase{"*.biz", false},
+		testCase{"*.biz", true},
 		testCase{"onizuka.homelinux.org", true},
 	}
 	for _, tc := range testCases {
@@ -162,14 +159,14 @@ func TestWildcardMatch(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	root := &DomainTrie{}
 	if !root.Empty() {
-		t.Fatalf("Empty() failed for initialized trie: %+v", spew.Sdump(root))
+		t.Fatalf("Empty() failed for initialized trie: %+v", root)
 	}
 	root, _ = MakeTrie([]string{})
 	if !root.Empty() {
-		t.Fatalf("Empty() failed for initialized trie: %+v", spew.Sdump(root))
+		t.Fatalf("Empty() failed for initialized trie: %+v", root)
 	}
 	root, _ = MakeTrie([]string{"google.com"})
 	if root.Empty() {
-		t.Fatalf("Empty() failed for initialized trie: %+v", spew.Sdump(root))
+		t.Fatalf("Empty() failed for initialized trie: %+v", root)
 	}
 }


### PR DESCRIPTION
ignore if domains are invalid when constructing the trie